### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ on:
 
 jobs:
   deploy_docs:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish Jazzy Docs


### PR DESCRIPTION
I changed macOS-latest to macos-latest as it was old syntax or typo.

It is described in [this documentation](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources)