### PR TITLE
Better link for creating PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Action expects the following to be true:
 ## Configuration
 |Key|Description|Required|
 |---|---|:---:|
-| `personal_access_token` | A personal access token with repo scope for pushing documentation to `gh-pages` branch. See [Creating a Personal Access Token](https://help.github.com/en/enterprise/2.17/user/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for creating the token and [Creating and Using Secrets](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) for including secrets to be used in tandem with Github Actions. | Yes |
+| `personal_access_token` | A personal access token with repo scope for pushing documentation to `gh-pages` branch. See [Creating a Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token) for creating the token and [Creating and Using Secrets](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) for including secrets to be used in tandem with Github Actions. | Yes |
 | `config` | The path to a Jazzy yaml or json configuration file| No |
 | `args` | Command line arguments to be passed to Jazzy. See `jazzy --help` on your local machine for available options| No |
 | `version` | The Jazzy version to run. Defaults to latest | No


### PR DESCRIPTION
The current URL has no styling and refers to the enterprise docs.